### PR TITLE
Fixed payload become null when save info checkbox is selected

### DIFF
--- a/src/components/Checkout/index.jsx
+++ b/src/components/Checkout/index.jsx
@@ -70,7 +70,7 @@ const Checkout = () => {
     setIsSubmitDisabled(true);
 
     createOrder(
-      { payload: dataToPersist },
+      { payload: values },
       {
         onSuccess: () => {
           setToLocalStorage(CHECKOUT_LOCAL_STORAGE_KEY, dataToPersist);


### PR DESCRIPTION
` const dataToPersist = checkboxRef.current.checked ? values : null;`

When checkbox is selected `dataToPersist` is becomes null, and it is send as payload. We should be sending form `values` as payload.